### PR TITLE
docs: add Spanish README

### DIFF
--- a/README.es-ES.md
+++ b/README.es-ES.md
@@ -1,0 +1,5 @@
+# Compilador de ML eficiente en energía
+
+Este repositorio contiene scripts de experimentos y registros.
+
+Repositorio de TVM modificado: [https://github.com/TheYonkk/tvm-energy-583/tree/pyJoule](https://github.com/TheYonkk/tvm-energy-583/tree/pyJoule)


### PR DESCRIPTION
Adds README.es-ES.md alongside the original documentation.

Generated by `inclusionai/ling-3.0-flash:free` via OpenRouter.